### PR TITLE
Affected Issue(s): #1505669070

### DIFF
--- a/src/main/resources/config/destination-database.yml
+++ b/src/main/resources/config/destination-database.yml
@@ -89,7 +89,7 @@ destination-database:
     - name: source_id
       typeName: bigserial
       sourceColumnName: id
-      isUnique: true
+      isUnique: false
     - name: source_date_deleted
       typeName: timestamp
       sourceColumnName: date_deleted

--- a/src/main/resources/config/source-database.yml
+++ b/src/main/resources/config/source-database.yml
@@ -33,13 +33,15 @@ source-database:
         WHERE
           event_json.obs_data ->> 'formSubmissionField' = 'namaBayi'
         LIMIT 1
-      )
+      ), ${source-database.tables[1].idColumnName} ->> '${source-database.tables[1].jsonPropertyName}' AS ${source-database.tables[1].idColumnName}_${source-database.tables[1].jsonPropertyName}
       FROM ${source-database.tables[1].name} c
-      WHERE c.${source-database.tables[1].idColumnName} > %s
+      WHERE (c.${source-database.tables[1].idColumnName} ->> '${source-database.tables[1].jsonPropertyName}')::timestamp with time zone > '%s'::timestamp with time zone
       AND c."json" ->> 'firstName' = '-'
       AND c."json" ->> 'lastName' = '-'
-      ORDER BY ${source-database.tables[1].idColumnName} ASC
-    idColumnName: id
+      ORDER BY c.${source-database.tables[1].idColumnName} ->> '${source-database.tables[1].jsonPropertyName}' ASC
+    idColumnName: json
+    jsonPath: $.${source-database.tables[1].jsonPropertyName}
+    jsonPropertyName: dateCreated
 
   - destinationTableName: ${destination-database.tables[2].name}
     name: core.event

--- a/src/main/resources/config/source-database.yml
+++ b/src/main/resources/config/source-database.yml
@@ -15,25 +15,38 @@ source-database:
   - destinationTableName: ${destination-database.tables[1].name}
     name: core.client
     query: SELECT c.*, (
+      CASE
+        WHEN (
+        SELECT
+          EXISTS(
+          SELECT
+            1
+          FROM
+            core."event" e
+          WHERE
+            e."json" ->> 'baseEntityId' = c."json" ->> 'baseEntityId'
+            AND e."json" ->> 'eventType' = 'Edit Bayi')) THEN (
         SELECT
           event_json.obs_data -> 'values' ->> 0 AS child_full_name
-        FROM (
+        FROM
+          (
           SELECT
-            jsonb_array_elements(
-              (
-                SELECT e."json"
-                FROM core."event" e
-                WHERE e."json" ->> 'baseEntityId' = c."json" ->> 'baseEntityId'
-                AND e."json" ->> 'eventType' = 'Child Registration'
-                ORDER BY e."json" ->> 'dateCreated' DESC
-                LIMIT 1
-              ) -> 'obs'
-            ) AS obs_data
-          ) event_json
+            jsonb_array_elements( ( SELECT e."json" FROM core."event" e WHERE e."json" ->> 'baseEntityId' = c."json" ->> 'baseEntityId' AND e."json" ->> 'eventType' = 'Edit Bayi' ORDER BY e."json" ->> 'dateCreated' DESC LIMIT 1 ) -> 'obs' ) AS obs_data ) event_json
         WHERE
           event_json.obs_data ->> 'formSubmissionField' = 'namaBayi'
-        LIMIT 1
-      ), ${source-database.tables[1].idColumnName} ->> '${source-database.tables[1].jsonPropertyName}' AS ${source-database.tables[1].idColumnName}_${source-database.tables[1].jsonPropertyName}
+        LIMIT 1)
+        ELSE (
+        SELECT
+          event_json.obs_data -> 'values' ->> 0 AS child_full_name
+        FROM
+          (
+          SELECT
+            jsonb_array_elements( ( SELECT e."json" FROM core."event" e WHERE e."json" ->> 'baseEntityId' = c."json" ->> 'baseEntityId' AND e."json" ->> 'eventType' = 'Child Registration' ORDER BY e."json" ->> 'dateCreated' DESC LIMIT 1 ) -> 'obs' ) AS obs_data ) event_json
+        WHERE
+          event_json.obs_data ->> 'formSubmissionField' = 'namaBayi'
+        LIMIT 1 )
+      END ) AS child_full_name,
+      ${source-database.tables[1].idColumnName} ->> '${source-database.tables[1].jsonPropertyName}' AS ${source-database.tables[1].idColumnName}_${source-database.tables[1].jsonPropertyName}
       FROM ${source-database.tables[1].name} c
       WHERE (c.${source-database.tables[1].idColumnName} ->> '${source-database.tables[1].jsonPropertyName}')::timestamp with time zone > '%s'::timestamp with time zone
       AND c."json" ->> 'firstName' = '-'


### PR DESCRIPTION
What this commit has achieved:
1. Changed criteria query for `client_child` DestinationTable.
Previously, select by its auto-incremental ID `id`. Changed into its
json ->> `dateCreated`.
2. Edited row in Bidan App was recently known to update `dateCreated` to
a more recent value (which is not the best practice of doing so,
`dateCreated` or other similar stuff should be NOT UPDATABLE).
3. This commit consists of hacky solution to overcome defect mentioned
in point 2 for `client_child` table.